### PR TITLE
Fix player skipping logic

### DIFF
--- a/scripts/game_board.gd
+++ b/scripts/game_board.gd
@@ -255,11 +255,11 @@ func get_slot_position(center, direction, cell_size):
 			return center
 
 func next_player():
-	current_player = (current_player % num_players) + 1
-	var counts = count_chips()
-	while counts.get(current_player, 0) == 0 and has_empty_cells():
-		current_player = (current_player % num_players) + 1
-	update_status()
+        current_player = (current_player % num_players) + 1
+        var counts = count_chips()
+        while counts.get(current_player, 0) == 0 and not has_empty_cells():
+                current_player = (current_player % num_players) + 1
+        update_status()
 
 func count_chips():
 	var counts = {}


### PR DESCRIPTION
## Summary
- fix condition for skipping eliminated players so new players get a turn

## Testing
- `apt-get update`
- `apt-get install -y vim-common`


------
https://chatgpt.com/codex/tasks/task_e_6872653613fc83339a2ca2585a24ef69